### PR TITLE
Fix example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
   "bip_util",
   "bip_utp",
   "bip_utracker",
+  "examples/simple_torrent"
 ]
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
   "bip_util",
   "bip_utp",
   "bip_utracker",
-  "examples/simple_torrent"
+  "examples/simple_torrent",
 ]
 
 [profile.bench]


### PR DESCRIPTION
This PR fixes the `simple_torrent` example. It now compiles with 7 warnings and 0 errors. I had to update a few references and function signatures to reflect the latest state of the library.

This change also adds the example to the workspace members in the root Cargo.toml. I don't know if this is appropriate, but it was the only way I could get cargo to build and run (and also get tooling to work in VSCode).